### PR TITLE
Add rudimentary support for LMS signing

### DIFF
--- a/include/lcp3.h
+++ b/include/lcp3.h
@@ -465,7 +465,7 @@ typedef struct __packed {
     uint8_t  Version;
     uint16_t KeySize;
     uint16_t HashAlg;
-    lms_signature_block signature;
+    lms_signature_block Signature;
 } lms_signature;
 
 typedef struct __packed {

--- a/include/lcp3.h
+++ b/include/lcp3.h
@@ -216,6 +216,7 @@ typedef struct __packed {
 #define TPM_ALG_NULL	0x0010
 #define TPM_ALG_SM3_256	0x0012
 #define TPM_ALG_ECC     0x0023
+#define TPM_ALG_LMS     0x0070
 
 #define TPM_ALG_MASK_NULL	    0x0000
 #define TPM_ALG_MASK_SHA1	    0x0001
@@ -240,6 +241,7 @@ typedef struct __packed {
 #define TPM_ALG_RSAPSS  0x0016
 #define TPM_ALG_ECDSA   0x0018
 #define TPM_ALG_SM2     0x001B
+#define TPM_ALG_LMS     0x0070
 
 typedef union {
     uint8_t    sha1[SHA1_DIGEST_SIZE];
@@ -359,11 +361,12 @@ typedef struct __packed {
 } lcp_policy_list_t2;
 
 /* LCP POLICY LIST 2.1 and its helper structs */
-#define SIGNATURE_VERSION 0x10
-#define MAX_RSA_KEY_SIZE  0x180
-#define MIN_RSA_KEY_SIZE  0x100
-#define MAX_ECC_KEY_SIZE  0x30
-#define MIN_ECC_KEY_SIZE  0x20
+#define SIGNATURE_VERSION        0x10
+#define HYBRID_SIGNATURE_VERSION 0x90
+#define MAX_RSA_KEY_SIZE         0x180
+#define MIN_RSA_KEY_SIZE         0x100
+#define MAX_ECC_KEY_SIZE         0x30
+#define MIN_ECC_KEY_SIZE         0x20
 
 typedef struct __packed {
     uint8_t  Version;
@@ -408,9 +411,96 @@ typedef struct __packed {
     rsa_signature  Signature;
 } rsa_key_and_signature;
 
+//LCP supports these LMS and LMOTS types:
+#define LMS_SHA256_M32_H20   0x8
+#define LMOTS_SHA256_N32_W4  0x3
+
+#define LMOTS_SIGNATURE_N_SIZE SHA256_DIGEST_SIZE // bytes in SHA256 digest
+#define LMOTS_SIGNATURE_P_SIZE 67 // Number of n-byte string elements that make up the LMOTS signature
+// With N and P we calculate the size of the signature block:
+#define LMOTS_SIGNATURE_BLOCK_SIZE (LMOTS_SIGNATURE_N_SIZE * LMOTS_SIGNATURE_P_SIZE)
+
+#define LMS_SIGNATURE_H_HEIGHT 20 // Height of the LMS tree
+#define LMS_SIGNATURE_M_SIZE SHA256_DIGEST_SIZE // Number of bytes in each LMS tree node
+
+// With H and M we calculate the size of the LMS signature:
+#define LMS_SIGNATURE_BLOCK_SIZE (LMS_SIGNATURE_H_HEIGHT * LMS_SIGNATURE_M_SIZE)
+
+#define LMS_SEED_SIZE 32
+#define LMS_MAX_PUBKEY_SIZE 56
+
+typedef struct __packed {
+    uint32_t LmsType; //Must be 0x8 (LMS_SHA256_M32_H20)
+    uint32_t LmotsType; //Must be 0x3 (LMOTS_SHA256_N32_W4)
+    uint8_t  I[16]; //LMS key identifier
+    uint8_t  T1[32]; //32-byte string associated with the 1st node of binary Merkel tree.
+} lms_xdr_key_data;
+
+typedef struct __packed {
+    uint8_t  Version;
+    uint16_t KeySize; //Must be 56 (LMS_MAX_PUBKEY_SIZE)
+    lms_xdr_key_data PubKey;
+} lms_public_key;
+
+typedef struct __packed {
+    uint32_t Type; // Must be 0x3 (LMOTS_SHA256_N32_W4)
+    uint8_t  Seed[LMS_SEED_SIZE];
+    uint8_t  Y[LMOTS_SIGNATURE_BLOCK_SIZE];
+} lmots_signature;
+
+typedef struct __packed {
+    uint32_t        Q; //Leaf number
+    lmots_signature Lmots;
+    uint32_t        LmsType; //Must be 0x8 (LMS_SHA256_M32_H20)
+    uint8_t         Path[LMS_SIGNATURE_BLOCK_SIZE];
+} lms_signature_block;
+
+typedef struct __packed {
+    uint8_t  Version;
+    uint16_t KeySize;
+    uint16_t HashAlg;
+    lms_signature_block signature;
+} lms_signature;
+
+typedef struct __packed {
+    uint8_t Version;
+    uint16_t KeyAlg;
+    lms_public_key Key;
+    uint16_t SigScheme;
+    lms_signature Signature;
+} lms_key_and_signature;
+
+typedef struct __packed {
+    uint8_t  Version; //bit7 of this value must be 1 to indicate hybrid signature
+    uint16_t RsaKeyAlg;
+    rsa_public_key RsaKey;
+    uint16_t RsaSigScheme; //TPM_ALG_RSAPSS
+    rsa_signature RsaSignature;
+    uint16_t LmsKeyAlg;
+    lms_public_key LmsKey;
+    uint16_t LmsSigScheme; //TPM_ALG_LMS
+    lms_signature LmsSignature;
+} rsa_lms_key_and_signature;
+
+typedef struct __packed {
+    uint8_t  Version; //bit7 of this
+    uint16_t EccKeyAlg;
+    ecc_public_key EccKey;
+    uint16_t EccSigScheme;
+    ecc_signature EccSignature;
+    uint16_t LmsKeyAlg;
+    lms_public_key LmsKey;
+    uint16_t LmsSigScheme; //TPM_ALG_LMS
+    lms_signature LmsSignature;
+} ecc_lms_key_and_signature;
+
 typedef union __packed {
-    rsa_key_and_signature    RsaKeyAndSignature;
-    ecc_key_and_signature    EccKeyAndSignature;
+    rsa_key_and_signature     RsaKeyAndSignature;
+    ecc_key_and_signature     EccKeyAndSignature;
+    lms_key_and_signature     LmsKeyAndSignature;
+    //New Hybrid signatures
+    rsa_lms_key_and_signature RsaLmsKeyAndSignature;
+    ecc_lms_key_and_signature EccLmsKeyAndSignature;
 } lcp_key_and_sig;
 
 typedef struct __packed {

--- a/include/lcp3.h
+++ b/include/lcp3.h
@@ -40,6 +40,10 @@
  * is incremented since layout is incompatible with previous revision.
  */
 
+#ifndef BITN
+#define BITN(n) (1 << (n))
+#endif
+
 /*--------- LCP UUID ------------*/
 #define LCP_POLICY_DATA_UUID   {0xab0d1925, 0xeee7, 0x48eb, 0xa9fc, \
                                {0xb, 0xac, 0x5a, 0x26, 0x2d, 0xe}}
@@ -226,15 +230,18 @@ typedef struct __packed {
 #define TPM_ALG_MASK_SHA512	    0x0080
 
 #define SIGN_ALG_MASK_NULL                  0x00000000
-#define SIGN_ALG_MASK_RSASSA_1024_SHA1      0x00000001 //Not supported
-#define SIGN_ALG_MASK_RSASSA_1024_SHA256    0x00000002
-#define SIGN_ALG_MASK_RSASSA_2048_SHA1      0x00000004 //Legacy
-#define SIGN_ALG_MASK_RSASSA_2048_SHA256    0x00000008 //ok
-#define SIGN_ALG_MASK_RSASSA_3072_SHA256    0x00000040 //ok
-#define SIGN_ALG_MASK_RSASSA_3072_SHA384    0x00000080 //ok
-#define SIGN_ALG_MASK_ECDSA_P256            0x00001000 //Sha256 ok
-#define SIGN_ALG_MASK_ECDSA_P384            0x00002000 //Sha 384
-#define SIGN_ALG_MASK_SM2                   0x00010000 //ok
+#define SIGN_ALG_MASK_RSASSA_1024_SHA1      BITN(0)  //Not supported
+#define SIGN_ALG_MASK_RSASSA_1024_SHA256    BITN(1)
+#define SIGN_ALG_MASK_RSASSA_2048_SHA1      BITN(2)  //Legacy
+#define SIGN_ALG_MASK_RSASSA_2048_SHA256    BITN(3)  //ok
+#define SIGN_ALG_MASK_RSASSA_3072_SHA256    BITN(6)  //ok
+#define SIGN_ALG_MASK_RSASSA_3072_SHA384    BITN(7)  //ok
+#define SIGN_ALG_MASK_ECDSA_P256            BITN(12) //Sha256 ok
+#define SIGN_ALG_MASK_ECDSA_P384            BITN(13) //Sha 384
+#define SIGN_ALG_MASK_LMS_P56B              BITN(14) //Public key size 56 bytes
+#define SIGN_ALG_MASK_SM2                   BITN(16) //ok
+#define SIGN_ALG_MASK_LMS_SHA256_M32_H20    BITN(17) //LMS LMOTS_SHA256_N32_W4 is used with
+
 
 /*--------- Signature algs ------------*/
 #define TPM_ALG_RSASSA  0x0014
@@ -362,7 +369,6 @@ typedef struct __packed {
 
 /* LCP POLICY LIST 2.1 and its helper structs */
 #define SIGNATURE_VERSION        0x10
-#define HYBRID_SIGNATURE_VERSION 0x90
 #define MAX_RSA_KEY_SIZE         0x180
 #define MIN_RSA_KEY_SIZE         0x100
 #define MAX_ECC_KEY_SIZE         0x30
@@ -470,37 +476,10 @@ typedef struct __packed {
     lms_signature Signature;
 } lms_key_and_signature;
 
-typedef struct __packed {
-    uint8_t  Version; //bit7 of this value must be 1 to indicate hybrid signature
-    uint16_t RsaKeyAlg;
-    rsa_public_key RsaKey;
-    uint16_t RsaSigScheme; //TPM_ALG_RSAPSS
-    rsa_signature RsaSignature;
-    uint16_t LmsKeyAlg;
-    lms_public_key LmsKey;
-    uint16_t LmsSigScheme; //TPM_ALG_LMS
-    lms_signature LmsSignature;
-} rsa_lms_key_and_signature;
-
-typedef struct __packed {
-    uint8_t  Version; //bit7 of this
-    uint16_t EccKeyAlg;
-    ecc_public_key EccKey;
-    uint16_t EccSigScheme;
-    ecc_signature EccSignature;
-    uint16_t LmsKeyAlg;
-    lms_public_key LmsKey;
-    uint16_t LmsSigScheme; //TPM_ALG_LMS
-    lms_signature LmsSignature;
-} ecc_lms_key_and_signature;
-
 typedef union __packed {
     rsa_key_and_signature     RsaKeyAndSignature;
     ecc_key_and_signature     EccKeyAndSignature;
     lms_key_and_signature     LmsKeyAndSignature;
-    //New Hybrid signatures
-    rsa_lms_key_and_signature RsaLmsKeyAndSignature;
-    ecc_lms_key_and_signature EccLmsKeyAndSignature;
 } lcp_key_and_sig;
 
 typedef struct __packed {

--- a/lcptools-v2/crtpol.c
+++ b/lcptools-v2/crtpol.c
@@ -684,7 +684,7 @@ int main (int argc, char *argv[])
             }
         case 'e':           /* LCP version */
             strlcpy(pol_ver_name, optarg, sizeof(pol_ver_name));
-            LOG("cmdline opt: sign: %s\n", pol_ver_name);
+            LOG("cmdline opt: LCP version: %s\n", pol_ver_name);
 
             pol_ver = str_to_pol_ver(pol_ver_name);
             if ( pol_ver == LCP_VER_NULL) {

--- a/lcptools-v2/crtpol.c
+++ b/lcptools-v2/crtpol.c
@@ -195,9 +195,9 @@ int create_legacy(void)
     }
 
     bool ok;
-    ok = write_file(policy_file, pol, policy_size);
+    ok = write_file(policy_file, pol, policy_size, 0);
     if ( ok && pol->policy_type == LCP_POLTYPE_LIST )
-        ok = write_file(poldata_file, poldata, get_policy_data_size(poldata));
+        ok = write_file(poldata_file, poldata, get_policy_data_size(poldata), 0);
 
     free(pol);
     if (poldata != NULL)
@@ -437,9 +437,9 @@ int create(void)
     LOG("pol alg=0x%x, mask=0x%x, aux_mask=0x%x, sign_mask=0x%x\n", pol->hash_alg, pol->lcp_hash_alg_mask, pol->aux_hash_alg_mask, pol->lcp_sign_alg_mask);
 
     bool ok;
-    ok = write_file(policy_file, pol, get_policy_size(pol));
+    ok = write_file(policy_file, pol, get_policy_size(pol), 0);
     if ( ok && pol->policy_type == LCP_POLTYPE_LIST )
-        ok = write_file(poldata_file, poldata, get_policy_data_size(poldata));
+        ok = write_file(poldata_file, poldata, get_policy_data_size(poldata), 0);
 
     free(pol);
     free(poldata);

--- a/lcptools-v2/crtpolelt.c
+++ b/lcptools-v2/crtpolelt.c
@@ -251,7 +251,7 @@ int main (int argc, char *argv[])
         elt->type = curr_plugin->type;
         elt->policy_elt_control = pol_elt_ctrl;
 
-        if ( !write_file(out_file, elt, elt->size) ) {
+        if ( !write_file(out_file, elt, elt->size, 0) ) {
             ERROR("Error: error writing element\n");
             free(elt);
             return 1;

--- a/lcptools-v2/hash.c
+++ b/lcptools-v2/hash.c
@@ -58,19 +58,12 @@ bool are_hashes_equal(const tb_hash_t *hash1, const tb_hash_t *hash2,
     int diff;
     if ( ( hash1 == NULL ) || ( hash2 == NULL ) )
         return false;
-
-    if ( hash_alg == TB_HALG_SHA1 )
-        return (memcmp_s(hash1, SHA1_LENGTH, hash2, SHA1_LENGTH, &diff) == 0 && diff == 0);
-    else if ( hash_alg == TB_HALG_SHA256 )
-        return (memcmp_s(hash1, SHA256_LENGTH, hash2, SHA256_LENGTH, &diff) == 0 && diff == 0);
-    else if ( hash_alg == TB_HALG_SM3 )
-        return (memcmp_s(hash1, SM3_LENGTH, hash2, SM3_LENGTH, &diff) == 0 && diff == 0);
-    else if ( hash_alg == TB_HALG_SHA384 )
-        return (memcmp_s(hash1, SHA384_LENGTH, hash2, SHA384_LENGTH, &diff) == 0 && diff == 0);
-    else if ( hash_alg == TB_HALG_SHA512 )
-        return (memcmp_s(hash1, SHA512_LENGTH, hash2, SHA512_LENGTH, &diff) == 0 && diff == 0);
-    else
+    
+    rsize_t hash_len = get_hash_size(hash_alg);
+    if ( hash_len == 0 )
         return false;
+
+    return (memcmp_s(hash1, hash_len, hash2, hash_len, &diff) == 0 && diff == 0);
 }
 
 /*
@@ -85,62 +78,33 @@ bool hash_buffer(const unsigned char* buf, size_t size, tb_hash_t *hash,
     if ( hash == NULL )
         return false;
 
-    if ( hash_alg == TB_HALG_SHA1 || hash_alg == TB_HALG_SHA1_LG ) {
-        EVP_MD_CTX *ctx = EVP_MD_CTX_create();
-        const EVP_MD *md;
+    EVP_MD_CTX *ctx = EVP_MD_CTX_create();
+    const EVP_MD *md;
 
+    if ( hash_alg == TB_HALG_SHA1 || hash_alg == TB_HALG_SHA1_LG ) {
         md = EVP_sha1();
-        EVP_DigestInit(ctx, md);
-        EVP_DigestUpdate(ctx, buf, size);
-        EVP_DigestFinal(ctx, hash->sha1, NULL);
-        EVP_MD_CTX_destroy(ctx);
-        return true;
+        
     }
     else if (hash_alg == TB_HALG_SHA256) {
-        EVP_MD_CTX *ctx = EVP_MD_CTX_create();
-        const EVP_MD *md;
-
         md = EVP_sha256();
-        EVP_DigestInit(ctx, md);
-        EVP_DigestUpdate(ctx, buf, size);
-        EVP_DigestFinal(ctx, hash->sha256, NULL);
-        EVP_MD_CTX_destroy(ctx);
-        return true;
     }
     else if (hash_alg == TB_HALG_SHA384) {
-        EVP_MD_CTX *ctx = EVP_MD_CTX_create();
-        const EVP_MD *md;
-
         md = EVP_sha384();
-        EVP_DigestInit(ctx, md);
-        EVP_DigestUpdate(ctx, buf, size);
-        EVP_DigestFinal(ctx, hash->sha384, NULL);
-        EVP_MD_CTX_destroy(ctx);
-        return true;
     }
     else if (hash_alg == TB_HALG_SHA512) {
-        EVP_MD_CTX *ctx = EVP_MD_CTX_create();
-        const EVP_MD *md;
-
         md = EVP_sha512();
-        EVP_DigestInit(ctx, md);
-        EVP_DigestUpdate(ctx, buf, size);
-        EVP_DigestFinal(ctx, hash->sha512, NULL);
-        EVP_MD_CTX_destroy(ctx);
-        return true;
     }
     else if (hash_alg == TB_HALG_SM3) {
-        EVP_MD_CTX *ctx = EVP_MD_CTX_create();
-        const EVP_MD *md;
         md = EVP_sm3();
-        EVP_DigestInit(ctx, md);
-        EVP_DigestUpdate(ctx, buf, size);
-        EVP_DigestFinal(ctx, hash->sm3, NULL);
-        EVP_MD_CTX_destroy(ctx);
-        return true;
     }
     else
         return false;
+    
+    EVP_DigestInit(ctx, md);
+    EVP_DigestUpdate(ctx, buf, size);
+    EVP_DigestFinal(ctx, hash->sha1, NULL);
+    EVP_MD_CTX_destroy(ctx);
+    return true;
 }
 
 /*

--- a/lcptools-v2/lcputils.c
+++ b/lcptools-v2/lcputils.c
@@ -426,6 +426,9 @@ uint32_t str_to_sig_alg_mask(const char *str, const uint16_t version, size_t siz
         else if (strncmp(str, "sm2", size) == 0) {
             return SIGN_ALG_MASK_SM2;
         }
+        else if (strncmp(str, "lms", size) == 0) {
+            return (SIGN_ALG_MASK_LMS_P56B | SIGN_ALG_MASK_LMS_SHA256_M32_H20);
+        }
         else if(strncmp(str, "0X", 2) || strncmp(str, "0x", 2)){
             return strtoul(str, NULL, 0);
         }

--- a/lcptools-v2/lcputils.c
+++ b/lcptools-v2/lcputils.c
@@ -720,7 +720,7 @@ Out: true/false on verification success or failure
         goto OPENSSL_ERROR;
     }
     
-    digest = malloc(get_lcp_hash_size(hashAlg));
+    digest = malloc(sizeof(tb_hash_t));
     if (digest == NULL) {
         ERROR("Error: failed to allocate digest");
         status = 0;

--- a/lcptools-v2/lcputils.h
+++ b/lcptools-v2/lcputils.h
@@ -43,7 +43,13 @@
 
 #define MAX_PATH           256
 
+#ifndef BITN
 #define BITN(x) (1 << (x))
+#endif
+
+#ifndef UNUSED
+#define UNUSED(x) (void)(x)
+#endif
 
 #include <openssl/evp.h>
 

--- a/lcptools-v2/lcputils.h
+++ b/lcptools-v2/lcputils.h
@@ -43,6 +43,8 @@
 
 #define MAX_PATH           256
 
+#define BITN(x) (1 << (x))
+
 #include <openssl/evp.h>
 
 //Helper struct to pass user input data to functions in pollist2 and pollist2_1
@@ -50,9 +52,11 @@ typedef struct sign_user_input {
     uint16_t sig_alg;
     uint16_t hash_alg;
     uint16_t rev_ctr;
+    bool     dump_sigblock;
     char list_file[MAX_PATH];
     char pubkey_file[MAX_PATH];
     char privkey_file[MAX_PATH];
+    char saved_sig_file[MAX_PATH];
 } sign_user_input;
 
 /*
@@ -71,11 +75,14 @@ extern void DISPLAY(const char *fmt, ...);
 
 extern size_t strlcpy(char *dst, const char *src, size_t siz);
 
-extern void print_hex(const char *prefix, const void *data, size_t n);
+extern void dump_hex(const char *prefix, const void *data, size_t n, uint16_t line_length);
+
+#define print_hex(prefix, data, n) dump_hex(prefix, data, n, 16)
+
 extern void parse_comma_sep_ints(char *s, uint16_t ints[],
                                  unsigned int *nr_ints);
 extern void *read_file(const char *file, size_t *length, bool fail_ok);
-extern bool write_file(const char *file, const void *data, size_t size);
+extern bool write_file(const char *file, const void *data, size_t size, size_t offset);
 extern bool parse_line_hashes(const char *line, tb_hash_t *hash, uint16_t alg);
 extern bool parse_file(const char *filename, bool (*parse_line)(const char *line));
 extern const char *hash_alg_to_str(uint16_t alg);
@@ -101,7 +108,9 @@ bool verify_rsa_signature(sized_buffer *data, sized_buffer *pubkey, sized_buffer
                           uint16_t hashAlg, uint16_t sig_alg, uint16_t list_ver);
 EVP_PKEY_CTX *rsa_get_sig_ctx(const char *key_path, uint16_t key_size_bytes);
 unsigned char *der_encode_sig_comps(sized_buffer *sig_r, sized_buffer *sig_s, int *length);
-
+char *strip_fname_extension(const char *fname);
+void print_xdr_lms_key_info(const lms_xdr_key_data *key);
+void print_lms_signature(const lms_signature_block *sig);
 
 #endif    /* __LCPUTILS_H__ */
 

--- a/lcptools-v2/mle_elt.c
+++ b/lcptools-v2/mle_elt.c
@@ -129,8 +129,8 @@ static void display(const char *prefix, const lcp_policy_element_t *elt)
     uint8_t *hash = (uint8_t *)&mle->hashes;
     unsigned int hash_size = get_hash_size(mle->hash_alg);
     for ( unsigned int i = 0; i < mle->num_hashes; i++ ) {
-        DISPLAY("%s hashes[%u]: ", prefix, i);
-        print_hex("", hash, hash_size);
+        DISPLAY("%s hashes[%u]:\n", prefix, i);
+        print_hex(prefix, hash, hash_size);
         hash += hash_size;
     }
 }

--- a/lcptools-v2/mle_elt_legacy.c
+++ b/lcptools-v2/mle_elt_legacy.c
@@ -128,8 +128,9 @@ static void display(const char *prefix, const lcp_policy_element_t *elt)
 
     uint8_t *hash = (uint8_t *)&mle->hashes;
     for ( unsigned int i = 0; i < mle->num_hashes; i++ ) {
-        DISPLAY("%s hashes[%u]: ", prefix, i);
-        print_hex("", hash, SHA1_DIGEST_SIZE);
+        DISPLAY("%s hashes[%u]\n ", prefix, i);
+        DISPLAY("%s", prefix);
+        print_hex("    ", hash, SHA1_DIGEST_SIZE);
         DISPLAY("\n");
         hash += SHA1_DIGEST_SIZE;
     }

--- a/lcptools-v2/pconf2_elt.c
+++ b/lcptools-v2/pconf2_elt.c
@@ -180,7 +180,7 @@ static lcp_policy_element_t *create(void)
     /* generate a TPM2B_DIGEST using the pcr composite */
     /* TODO: not sure if this is correct, but reuse the pcr hash alg */
     pcr_digest_size = sizeof(*pcr_digest) + pcr_alg_size;
-    pcr_digest = malloc(pcr_digest_size);
+    pcr_digest = malloc(sizeof(tb_hash_t));
     if (!pcr_digest) {
         ERROR("Error: failed to allocate a TPM2B_DIGEST\n");
         goto err;

--- a/lcptools-v2/pconf_legacy.c
+++ b/lcptools-v2/pconf_legacy.c
@@ -324,7 +324,7 @@ static lcp_policy_element_t *create(void)
             ERROR("Error: no pcrs were selected.\n");
             return NULL;
         }
-        digest = malloc(SHA1_DIGEST_SIZE);
+        digest = malloc(sizeof(tb_hash_t));
         if (digest == NULL) {
             ERROR("Error: failed to allocate memory for digest buffer.\n");
             return NULL;

--- a/lcptools-v2/pol.c
+++ b/lcptools-v2/pol.c
@@ -143,8 +143,8 @@ void display_legacy_policy(const char *prefix, const lcp_policy_t *pol)
     if (pol->version < LCP_VER_2_4) {
         DISPLAY("%s max_biosac_min_ver: 0x%x\n", prefix, pol->reserved2);
     }
-    DISPLAY("%s policy_hash: ", prefix);
-    print_hex("", &pol->policy_hash, SHA1_DIGEST_SIZE);
+    DISPLAY("%s \n ", prefix);
+    print_hex(prefix, &pol->policy_hash, SHA1_DIGEST_SIZE);
 }
 
 void display_policy(const char *prefix, const lcp_policy_t2 *pol, bool brief)
@@ -181,8 +181,8 @@ void display_policy(const char *prefix, const lcp_policy_t2 *pol, bool brief)
     else {
         DISPLAY("%s reserved2: 0x%x\n", prefix, pol->aux_hash_alg_mask);
     }
-    DISPLAY("%s policy_hash: ", prefix);
-    print_hex("", &pol->policy_hash, get_lcp_hash_size(pol->hash_alg));
+    DISPLAY("%s policy_hash:\n", prefix);
+    print_hex(prefix, &pol->policy_hash, get_lcp_hash_size(pol->hash_alg));
 }
 
 const char *policy_type_to_str(uint8_t type)

--- a/lcptools-v2/polelt.c
+++ b/lcptools-v2/polelt.c
@@ -89,12 +89,12 @@ bool verify_policy_element(const lcp_policy_element_t *elt, size_t size)
 void display_policy_element(const char *prefix,
                             const lcp_policy_element_t *elt, bool brief)
 {
-    DISPLAY("%s size: 0x%x (%u)\n", prefix, elt->size, elt->size);
+    DISPLAY("%s size: 0x%x\n", prefix, elt->size);
 
     polelt_plugin_t *plugin = find_polelt_plugin_by_type(elt->type);
 
     const char *type_str = (plugin == NULL) ? "unknown" : plugin->type_string;
-    DISPLAY("%s type: \'%s\' (%u)\n", prefix, type_str, elt->type);
+    DISPLAY("%s type: \'0x%x\' (%s)\n", prefix, elt->type, type_str);
 
     DISPLAY("%s policy_elt_control: 0x%08x\n", prefix,
             elt->policy_elt_control);

--- a/lcptools-v2/pollist1.c
+++ b/lcptools-v2/pollist1.c
@@ -452,7 +452,7 @@ bool write_tpm12_policy_list_file(const char *file, const lcp_policy_list_t *pol
         }
     }
 
-    return write_file(file, pollist, len);
+    return write_file(file, pollist, len, 0);
 }
 
 bool rsa_sign_list1_data(lcp_policy_list_t *pollist, const char *privkey_file)

--- a/lcptools-v2/pollist2.c
+++ b/lcptools-v2/pollist2.c
@@ -812,7 +812,7 @@ bool write_tpm20_policy_list_file(const char *file,
         }
     }
 
-    return write_file(file, pollist, len);
+    return write_file(file, pollist, len, 0);
 }
 
 lcp_signature_t2 *read_rsa_pubkey_file(const char *file)

--- a/lcptools-v2/pollist2_1.c
+++ b/lcptools-v2/pollist2_1.c
@@ -134,7 +134,7 @@ lcp_policy_list_t2_1 *get_policy_list_2_1_data(const void *raw_data, size_t base
     }
 
     new_pollist = malloc(key_signature_offset);
-    key_alg = *((uint16_t *) raw_data + key_signature_offset + 1);
+    key_alg = *((uint16_t *)(raw_data + key_signature_offset + 1));
     sig = create_empty_signature_2_1(key_alg);
     if (sig == NULL || new_pollist == NULL ) {
         ERROR("ERROR: unable to create signature.\n");

--- a/lcptools-v2/pollist2_1.c
+++ b/lcptools-v2/pollist2_1.c
@@ -1066,18 +1066,18 @@ bool verify_tpm20_pollist_2_1_lms_sig(const lcp_policy_list_t2_1 *pollist)
 
     tb_hash_t policy_list_hash = { 0 };
 
-    fp_key = fopen(pub_key_fname, "wb+");
+    fp_key = fopen(pub_key_fname, "wb");
     if ( fp_key == NULL ) {
         ERROR("Error: failed to open file for writing key.\n");
         return false;
     }
-    fp_sig = fopen(sig_fname, "wb+");
+    fp_sig = fopen(sig_fname, "wb");
     if ( fp_sig == NULL ) {
         ERROR("Error: failed to open file for writing signature.\n");
         fclose(fp_key);
         return false;
     }
-    fp_list_data = fopen(list_data_fname, "wb+");
+    fp_list_data = fopen(list_data_fname, "wb");
     if (fp_list_data == NULL) {
         ERROR("Error: failed to open file for writing list data.\n");
         fclose(fp_key);
@@ -2262,8 +2262,12 @@ bool lms_sign_list_2_1_data(lcp_policy_list_t2_1 *pollist, const char *privkey_f
         goto CLOSE_FILES;
     }
 
+    fclose(fp_list_digest);
+    fp_list_digest = NULL; //We don't need it anymore
+
     //Here we call the LMS demo tool to sign the digest
     sprintf(cli, fmt, privkey_file_no_ext, lcp_list_digest_file);
+    printf("Running command: %s\n", cli);
     status = system(cli);
     if (status != EOK) {
         ERROR("ERROR: failed to sign list data.\n");

--- a/lcptools-v2/pollist2_1.c
+++ b/lcptools-v2/pollist2_1.c
@@ -77,9 +77,12 @@ static lcp_signature_2_1 *read_rsa_pubkey_file_2_1(const char *pubkey_file);
 static lcp_signature_2_1 *read_ecdsa_pubkey_file_2_1(const char *pubkey_file);
 static bool ec_sign_list_2_1_data(lcp_policy_list_t2_1 *pollist, const char *privkey_file);
 static bool rsa_sign_list_2_1_data(lcp_policy_list_t2_1 *pollist, const char *privkey_file);
+static bool lms_sign_list_2_1_data(lcp_policy_list_t2_1 *pollist, const char *privkey_file);
 static lcp_policy_list_t2_1 *policy_list2_1_rsa_sign(lcp_policy_list_t2_1 *pollist,
-uint16_t rev_ctr, uint16_t hash_alg, uint16_t sig_alg, const char *pubkey_file,
-                                                      const char *privkey_file);
+                                                     uint16_t rev_ctr, uint16_t hash_alg, 
+                                                     uint16_t sig_alg, const char *pubkey_file,
+                                                     const char *privkey_file);
+static lcp_signature_2_1 *create_empty_signature_2_1(uint16_t sig_alg);
 static lcp_policy_list_t2_1 *policy_list2_1_ec_sign(lcp_policy_list_t2_1 *pollist,
 uint16_t rev_ctr, uint16_t sig_alg, const char *pubkey_file, const char *privkey_file);
 
@@ -102,6 +105,7 @@ lcp_policy_list_t2_1 *get_policy_list_2_1_data(const void *raw_data, size_t base
     lcp_policy_list_t2_1 *new_pollist = NULL; //Will return this
     sig_key_2_1_header *header;
     lcp_signature_2_1 *sig = NULL;
+    uint16_t key_alg;
     int status;
 
     LOG("[get_policy_list_2_1_data]\n");
@@ -129,7 +133,8 @@ lcp_policy_list_t2_1 *get_policy_list_2_1_data(const void *raw_data, size_t base
     }
 
     new_pollist = malloc(key_signature_offset);
-    sig = create_empty_rsa_signature_2_1();
+    key_alg = *((uint16_t *) raw_data + key_signature_offset + 1);
+    sig = create_empty_signature_2_1(key_alg);
     if (sig == NULL || new_pollist == NULL ) {
         ERROR("ERROR: unable to create signature.\n");
         return NULL;
@@ -168,6 +173,17 @@ lcp_policy_list_t2_1 *get_policy_list_2_1_data(const void *raw_data, size_t base
         }
         new_pollist->KeySignatureOffset = 0x0; // Reset keysignatureoffset
         new_pollist = add_tpm20_signature_2_1(new_pollist, sig, TPM_ALG_ECDSA);
+        if (new_pollist == NULL ) {
+            ERROR("ERROR: Cannot add TPM_signature_2_1");
+            free(sig);
+            return NULL;
+        }
+        break;
+    case TPM_ALG_LMS:
+        //LMS signature is fixed size, so we can just copy it to the new list
+        memcpy_s((void *) sig, sizeof(lms_key_and_signature) + sizeof(uint16_t), (const void *) raw_data + key_signature_offset - offsetof(lcp_signature_2_1, KeyAndSignature),
+                 sizeof(lms_key_and_signature) + sizeof(uint16_t));
+        new_pollist = add_tpm20_signature_2_1(new_pollist, sig, TPM_ALG_LMS);
         if (new_pollist == NULL ) {
             ERROR("ERROR: Cannot add TPM_signature_2_1");
             free(sig);
@@ -246,6 +262,34 @@ lcp_policy_list_t2_1 *read_policy_list_2_1_file(bool sign_it, const char *list_f
     }
 }
 
+lcp_signature_2_1 *create_empty_signature_2_1(uint16_t sig_alg)
+{
+    /*
+    This function: returns empty signature structure. Empty == just 0s inside
+
+    In: None
+    Out: Pointer to empty structure
+
+    */
+    lcp_signature_2_1 *sig = NULL;
+
+    switch (sig_alg) {
+        case TPM_ALG_RSA:
+            sig = create_empty_rsa_signature_2_1();
+            break;
+        case TPM_ALG_ECC:
+            sig = create_empty_ecc_signature_2_1();
+            break;
+        case TPM_ALG_LMS:
+            sig = create_empty_lms_signature_2_1();
+            break;
+        default:
+            ERROR("Error: unknown signature algorithm.\n");
+            return NULL;
+    }
+    return sig;
+}
+
 lcp_signature_2_1 *create_empty_ecc_signature_2_1(void)
 /*
 This function: returns empty ecc sig structure. Empty == just 0s inside
@@ -268,6 +312,21 @@ Out: Pointer to an empty structure
     else {
         return NULL;
     }
+}
+
+lcp_signature_2_1 *create_empty_lms_signature_2_1(void)
+/*
+    This function: returns empty (only zeroes) lms sig structure. Caller must free it after use.
+*/
+{
+    size_t sig_size = sizeof(lms_key_and_signature) + offsetof(lcp_signature_2_1,
+                                                                KeyAndSignature);
+
+    lcp_signature_2_1 *sig = calloc(sig_size, 1);
+    if (sig == NULL) {
+        return NULL;
+    }
+    return sig;
 }
 
 lcp_signature_2_1 *create_empty_rsa_signature_2_1(void)
@@ -372,7 +431,7 @@ Out: True on success, false on error
     }
     if (verbose) {
         DISPLAY("Raw policy list data:\n");
-        print_hex("        ", (const void *) pollist, size);
+        print_hex("    ", (const void *) pollist, size);
     }
     //Major ver must be 3, minor ver must be 0
     if ( MAJOR_VER(pollist->Version) != \
@@ -482,6 +541,10 @@ Out: Nothing
     }
     if (sig_header->key_alg == TPM_ALG_ECC) {
         display_tpm20_signature_2_1("        ", sig, TPM_ALG_ECDSA);
+        return;
+    }
+    if (sig_header->key_alg == TPM_ALG_LMS) {
+        display_tpm20_signature_2_1("        ", sig, TPM_ALG_LMS);
         return;
     }
     return;
@@ -645,6 +708,7 @@ bool get_rsa_signature_2_1_data(lcp_signature_2_1 *empty_sig, void *raw_data)
 
     return true;
 }
+
 bool verify_tpm20_pollist_2_1_sig(lcp_policy_list_t2_1 *pollist)
 {
     bool result;
@@ -1119,6 +1183,44 @@ Out:
            sig->KeyAndSignature.EccKeyAndSignature.Signature.sigRsigS+keysize,
                                                                        keysize);
         break;
+    case TPM_ALG_LMS:
+        DISPLAY("LMS_KEY_AND_SIGNATURE:\n");
+        keysize = sig->KeyAndSignature.LmsKeyAndSignature.Key.KeySize;
+        DISPLAY ("%s Version: 0x%x\n", prefix,
+                               sig->KeyAndSignature.LmsKeyAndSignature.Version);
+
+        DISPLAY (
+            "%s KeyAlg: 0x%x (%s)\n",
+            prefix,
+            sig->KeyAndSignature.LmsKeyAndSignature.KeyAlg,
+            key_alg_to_str(sig->KeyAndSignature.LmsKeyAndSignature.KeyAlg)
+        );
+
+        DISPLAY("LMS_PUBLIC_KEY:\n");
+        DISPLAY ("%s Version: 0x%x\n", prefix,
+                            sig->KeyAndSignature.LmsKeyAndSignature.Key.Version);
+        DISPLAY ("%s KeySize: 0x%x\n", prefix,
+                        sig->KeyAndSignature.LmsKeyAndSignature.Key.KeySize);
+        
+        print_xdr_lms_key_info((const lms_xdr_key_data *) &sig->KeyAndSignature.LmsKeyAndSignature.Key.PubKey);
+        DISPLAY("End of LMS_PUBLIC_KEY\n");
+        DISPLAY (
+            "%s SigScheme: 0x%x (%s)\n",
+            prefix,
+            sig->KeyAndSignature.LmsKeyAndSignature.SigScheme,
+            sig_alg_to_str(sig->KeyAndSignature.LmsKeyAndSignature.SigScheme)
+        );
+        DISPLAY("LMS_SIGNATURE:\n");
+        DISPLAY ("%s Version: 0x%x\n", prefix,
+                            sig->KeyAndSignature.LmsKeyAndSignature.Signature.Version);
+        DISPLAY ("%s KeySize: 0x%x\n", prefix,
+                            sig->KeyAndSignature.LmsKeyAndSignature.Signature.KeySize);
+        DISPLAY("%s HashAlg: 0x%x (%s)\n",
+            prefix,
+            sig->KeyAndSignature.LmsKeyAndSignature.Signature.HashAlg,
+            hash_alg_to_str(sig->KeyAndSignature.LmsKeyAndSignature.Signature.HashAlg)
+        );
+        print_lms_signature((const lms_signature_block *) &sig->KeyAndSignature.LmsKeyAndSignature.Signature.signature);
     default:
         break;
     }
@@ -1142,54 +1244,42 @@ Out: copy of a list with signature added
         LOG("add_tpm20_signature_2_1 pollist or signature == NULL");
         return NULL;
     }
+    old_size = get_tpm20_policy_list_2_1_size(pollist);
+    if ( old_size != offsetof(lcp_policy_list_t2_1, PolicyElements) +
+                                                pollist->PolicyElementsSize) {
+        DISPLAY("List already signed");
+        //Check if we want to hybrid sign with LMS
+        if (sig->KeyAndSignature.RsaKeyAndSignature.Version & BITN(7) ) {
+            DISPLAY("Hybrid signature not supported yet.\n");
+        }   
+        return pollist;
+    }
     switch (sig_alg)
     {
     case TPM_ALG_RSASSA:
     case TPM_ALG_RSAPSS:
-        old_size = get_tpm20_policy_list_2_1_size(pollist);
-        if ( old_size != offsetof(lcp_policy_list_t2_1, PolicyElements) +
-                                                  pollist->PolicyElementsSize) {
-            DISPLAY("List already signed");
-            return pollist;
-        }
-        sig_size = offsetof(lcp_signature_2_1, KeyAndSignature) +
-                                                  sizeof(rsa_key_and_signature);
-        pollist->KeySignatureOffset = old_size + offsetof(lcp_signature_2_1,
-                                                               KeyAndSignature);
-        new_pollist = realloc(pollist, old_size + sig_size);
-
-        if ( new_pollist == NULL ){
-            ERROR("Error: failed to allocate memory\n");
-            free(pollist);
-            return NULL;
-        }
-        sig_begin = old_size;
-        memcpy_s((void *)new_pollist + sig_begin, sig_size, sig, sig_size);
-        return new_pollist;
+        sig_size = offsetof(lcp_signature_2_1, KeyAndSignature) + sizeof(rsa_key_and_signature);
+        break;
     case TPM_ALG_SM2: // Process is the same as for ECDSA
     case TPM_ALG_ECDSA:
-        old_size = get_tpm20_policy_list_2_1_size(pollist);
-        if ( old_size != offsetof(lcp_policy_list_t2_1, PolicyElements) +
-                                                  pollist->PolicyElementsSize) {
-            DISPLAY("ERROR: List already signed");
-            return pollist;
-        }
-        sig_size = offsetof(lcp_signature_2_1, KeyAndSignature) +
-                                                  sizeof(ecc_key_and_signature);
-        pollist->KeySignatureOffset = old_size + offsetof(lcp_signature_2_1,
-                                                               KeyAndSignature);
-        new_pollist = realloc(pollist, old_size + sig_size);
-        if ( new_pollist == NULL ){
-            ERROR("Error: failed to allocate memory\n");
-            free(pollist);
-            return NULL;
-        }
-        sig_begin = old_size;
-        memcpy_s((void *)new_pollist + sig_begin, sig_size, sig, sig_size);
-        return new_pollist;
+        sig_size = offsetof(lcp_signature_2_1, KeyAndSignature) + sizeof(ecc_key_and_signature);
+        break;
+    case TPM_ALG_LMS:
+        sig_size = offsetof(lcp_signature_2_1, KeyAndSignature) + sizeof(lms_key_and_signature);
+        break;
     default:
         return NULL;
     }
+    pollist->KeySignatureOffset = old_size + offsetof(lcp_signature_2_1, KeyAndSignature);
+    new_pollist = realloc(pollist, old_size + sig_size);
+    if ( new_pollist == NULL ){
+        ERROR("Error: failed to allocate memory\n");
+        free(pollist);
+        return NULL;
+    }
+    sig_begin = old_size;
+    memcpy_s((void *)new_pollist + sig_begin, sig_size, sig, sig_size);
+    return new_pollist;
 }
 
 bool calc_tpm20_policy_list_2_1_hash(const lcp_policy_list_t2_1 *pollist,
@@ -1395,6 +1485,15 @@ Out: handle to buffer containing contiguous policy list data.
             return NULL;
         }
         break;
+    case TPM_ALG_LMS:
+        //We can just dump entire LMS signature as is
+        result = memcpy_s((void *)to_buffer+bytes_written, buffer_size, (const void *) sig, sizeof(lms_key_and_signature) + offsetof(lcp_signature_2_1, KeyAndSignature));
+        if (result != EOK) {
+            ERROR("Error: failed to copy list data.\n");
+            free(to_buffer);
+            return NULL;
+        }
+        break;
     default:
         ERROR("Error: unsupported key algorithm.\n");
         free(to_buffer);
@@ -1434,6 +1533,10 @@ Out: signature size, or 0 on error.
     case TPM_ALG_ECC:
         key_size_bytes = sig->KeyAndSignature.EccKeyAndSignature.Key.KeySize / 8;
         sig_size = sizeof(ecc_key_and_signature) - 4 * (MAX_ECC_KEY_SIZE - key_size_bytes);
+        return sig_size;
+    case TPM_ALG_LMS:
+        //LMS is fixed size
+        sig_size = sizeof(lms_key_and_signature);
         return sig_size;
     default:
         ERROR("Error: unknown key algorithm.\n");
@@ -1478,6 +1581,7 @@ Out: real size of a list, or 0 on failure
 }
 
 bool write_tpm20_policy_list_2_1_file(const char *file,
+                                      const char *signature_file,
                                       const lcp_policy_list_t2_1 *pollist)
 /*
 This function: writes LCP policy list 2.1 to a file
@@ -1488,7 +1592,8 @@ Out: true/false write success or failure
 */
 {
     unsigned char *buffer = NULL;
-    size_t buffer_size; //For unsigned list
+    size_t buffer_size; //For signed list
+    unsigned char *signature_p = NULL;
 
     LOG("[write_tpm20_policy_list_2_1_file]\n");
     if (pollist == NULL) {
@@ -1498,7 +1603,7 @@ Out: true/false write success or failure
 
     //No sig:
     if ( pollist->KeySignatureOffset == 0 ) {
-        if (!write_file(file, (const void *) pollist, get_tpm20_policy_list_2_1_size(pollist))) {
+        if (!write_file(file, (const void *) pollist, get_tpm20_policy_list_2_1_size(pollist), 0)) {
             ERROR("ERROR: Failed to write.\n");
             return false;
         }
@@ -1511,16 +1616,27 @@ Out: true/false write success or failure
         ERROR("ERROR: Failed to allocate buffer.\n");
         return false;
     }
-    if (!write_file(file, buffer, buffer_size)) {
+    if (!write_file(file, buffer, buffer_size, 0)) {
         ERROR("ERROR: Failed to write.\n");
         free(buffer);
         return false;
     }
     else {
-        LOG("Write successful.\n");
-        free(buffer);
-        return true;
+        LOG("Policy List 2.1 write successful.\n");
     }
+    if (signature_file != NULL) {
+        signature_p = buffer + pollist->KeySignatureOffset;
+        if (!write_file(signature_file, signature_p, buffer_size - pollist->KeySignatureOffset, pollist->KeySignatureOffset)) {
+            ERROR("ERROR: Failed to write signature.\n");
+            free(buffer);
+            return false;
+        }
+        else {
+            LOG("LCP Signature 2.1 write successful.\n");
+        }
+    }
+    free(buffer);
+    return true;
 }
 
 static lcp_signature_2_1 *read_rsa_pubkey_file_2_1(const char *file)
@@ -1953,6 +2069,156 @@ static lcp_signature_2_1 *read_ecdsa_pubkey_file_2_1(const char *pubkey_file)
         return NULL;
 }
 
+static lcp_signature_2_1 *read_lms_pubkey_file_2_1(const char *pubkey_file)
+{
+    lcp_signature_2_1 *sig = NULL;
+    lms_public_key lms_pubkey = { 0 };
+    FILE *fp = NULL;
+
+    fp = fopen(pubkey_file, "rb");
+    if (fp == NULL) {
+        ERROR("ERROR: cannot open file.\n");
+        return NULL;
+    }
+    //Cisco hash-sigs tool adds "levels" field to the key, we need to skip it
+    //but first make sure the key size is correct
+    fseek(fp, SEEK_SET, SEEK_END);
+    if (ftell(fp) != LMS_MAX_PUBKEY_SIZE + sizeof(uint32_t)) {
+        ERROR("ERROR: incorrect LMS key size.\n");
+        fclose(fp);
+        return NULL;
+    }
+    fseek(fp, sizeof(uint32_t), SEEK_SET);
+    //Read the public key to buffer and close the file
+    fread((void *) &lms_pubkey.PubKey, sizeof(lms_pubkey.PubKey), 1, fp);
+    fclose(fp);
+
+    sig = create_empty_lms_signature_2_1();
+    if (sig == NULL) {
+        ERROR("ERROR: failed to generate LMS signature 2.1.\n");
+        return NULL;
+    }
+    sig->KeyAndSignature.LmsKeyAndSignature.Version = SIGNATURE_VERSION;
+    sig->KeyAndSignature.LmsKeyAndSignature.KeyAlg = TPM_ALG_LMS;
+    sig->KeyAndSignature.LmsKeyAndSignature.Key.Version = SIGNATURE_VERSION;
+    sig->KeyAndSignature.LmsKeyAndSignature.Key.KeySize = LMS_MAX_PUBKEY_SIZE;
+    if (memcpy_s((void *) &sig->KeyAndSignature.LmsKeyAndSignature.Key.PubKey, LMS_MAX_PUBKEY_SIZE,
+            (const void *) &lms_pubkey.PubKey, sizeof(lms_pubkey.PubKey)) != EOK ) {
+                ERROR("ERROR: Cannot copy key data to LCP signature\n");
+                free(sig);
+                return NULL;
+            }
+    sig->KeyAndSignature.LmsKeyAndSignature.SigScheme = TPM_ALG_LMS;
+
+    return sig;
+}
+
+bool lms_sign_list_2_1_data(lcp_policy_list_t2_1 *pollist, const char *privkey_file)
+{
+    FILE *fp_list_digest = NULL;
+    FILE *fp_signature = NULL;
+    sized_buffer *digest = NULL;
+    lcp_signature_2_1 *sig = NULL;
+
+    int status = EOK;
+    const char *sig_file = "lcp_list_digest.sig";
+    const char *lcp_list_digest_file = "lcp_list_digest";
+    char *privkey_file_no_ext = strip_fname_extension(privkey_file);
+    char cli[16 + (MAX_PATH * 2)] = {0};
+    const char *fmt = "demo sign %s %s";
+
+    DISPLAY("[lms_sign_list_2_1_data]\n");
+    
+    if (pollist == NULL || privkey_file == NULL) {
+        ERROR("ERROR: lcp policy list or private key file is not defined.\n");
+        return false;
+    }
+    
+    //Create files
+    fp_list_digest = fopen(lcp_list_digest_file, "wb+");
+    if (fp_list_digest == NULL) {
+        ERROR("ERROR: cannot create file %s.\n", lcp_list_digest_file);
+        return false;
+    }
+
+    //Prepare buffer for the LCP list digest
+    digest = allocate_sized_buffer(SHA256_DIGEST_SIZE);
+    if (digest == NULL) {
+        ERROR("ERROR: failed to allocate buffer.\n");
+        goto CLOSE_FILES;
+    }
+    digest->size = SHA256_DIGEST_SIZE;
+
+    //Hash the list data
+    status = hash_buffer((const unsigned char *) pollist, pollist->KeySignatureOffset,
+                         (tb_hash_t *) digest->data, TPM_ALG_SHA256);
+    if (!status) {
+        ERROR("ERROR: failed to hash list data.\n");
+        goto CLOSE_FILES;
+    }
+    if (verbose) {
+        LOG("List digest:\n");
+        print_hex("    ", (const void *) digest->data, digest->size);
+    }
+
+    //Now we write the digest to the file
+    status = fwrite((const void *) digest->data, 1, digest->size, fp_list_digest);
+    if ((size_t) status != digest->size) {
+        ERROR("ERROR: failed to write digest to file.\n");
+        goto CLOSE_FILES;
+    }
+
+    //Here we call the LMS demo tool to sign the digest
+    sprintf(cli, fmt, privkey_file_no_ext, lcp_list_digest_file);
+    status = system(cli);
+    if (status != EOK) {
+        ERROR("ERROR: failed to sign list data.\n");
+        ERROR("Check if LMS Demo tool is installed and in PATH.\n");
+        goto CLOSE_FILES;
+    }
+
+    //Now we can open the signature file and read the signature
+    fp_signature = fopen(sig_file, "rb");
+    if (fp_signature == NULL) {
+        ERROR("ERROR: cannot create file %s.\n", sig_file);
+        goto CLOSE_FILES;
+    }
+
+    //Read the signature into signature structure
+    sig = get_tpm20_signature_2_1(pollist);
+    sig->KeyAndSignature.LmsKeyAndSignature.SigScheme = TPM_ALG_LMS;
+    sig->KeyAndSignature.LmsKeyAndSignature.Signature.HashAlg = TPM_ALG_SHA256;
+    sig->KeyAndSignature.LmsKeyAndSignature.Signature.Version = SIGNATURE_VERSION;
+    sig->KeyAndSignature.LmsKeyAndSignature.Signature.KeySize = LMS_MAX_PUBKEY_SIZE;
+
+    //Now we copy the signature from file but remember to move file pointer
+    //to skip first 4 bytes (similar to public key)
+    fseek(fp_signature, sizeof(uint32_t), SEEK_SET);
+    size_t copy_size = sizeof(lms_signature_block);
+    if (fread((void *) &sig->KeyAndSignature.LmsKeyAndSignature.Signature.signature, sizeof(uint8_t), copy_size, fp_signature) == 0) {
+        ERROR("ERROR: failed to read signature file.\n");
+        goto CLOSE_FILES;
+    }
+
+    //Dump sigblock if verbose is on
+    if (verbose) {
+        DISPLAY("Signature blokc:\n");
+        print_hex("    ", (const void *) &sig->KeyAndSignature.LmsKeyAndSignature.Signature.signature, copy_size);
+
+    }
+
+CLOSE_FILES:
+    if (fp_list_digest != NULL)
+        fclose(fp_list_digest);
+    if (fp_signature != NULL)
+        fclose(fp_signature);
+    if (privkey_file_no_ext != NULL)
+        free(privkey_file_no_ext);
+    if (digest != NULL)
+        free(digest);
+    return true;
+}
+
 bool ec_sign_list_2_1_data(lcp_policy_list_t2_1 *pollist, const char *privkey_file)
 {
     /*
@@ -2132,6 +2398,45 @@ static lcp_policy_list_t2_1 *policy_list2_1_ec_sign(lcp_policy_list_t2_1 *pollis
     return pollist;
 }
 
+static lcp_policy_list_t2_1 *policy_list2_1_lms_sign(lcp_policy_list_t2_1 *pollist,
+                                                uint16_t rev_ctr,
+                                                uint16_t sig_alg,
+                                                const char *pubkey_file,
+                                                const char *privkey_file)
+{
+    lcp_signature_2_1 *sig = NULL;
+    bool result;
+
+    if (pollist == NULL) {
+        ERROR("Error: cannot create lcp signature 2.1.\n");
+        return NULL;
+    }
+
+    sig = read_lms_pubkey_file_2_1(pubkey_file);
+    if (sig == NULL) {
+        ERROR("Error: failed to read LMS key.\n");
+        return NULL;
+    }
+    sig->RevocationCounter = rev_ctr;
+    sig->KeyAndSignature.LmsKeyAndSignature.SigScheme = sig_alg;
+    pollist = add_tpm20_signature_2_1(pollist, sig, sig_alg);
+    if (pollist == NULL) {
+        ERROR("Error: failed to add lcp_signature_2_1 to list.\n");
+        free(sig);
+        return NULL;
+    }
+    
+    result = lms_sign_list_2_1_data(pollist, privkey_file);
+    if (!result) {
+        ERROR("Error: failed to sign list data.\n");
+        free(sig);
+        free(pollist);
+        return NULL;
+    }
+
+    return pollist;
+}
+
 bool sign_lcp_policy_list_t2_1(sign_user_input user_input)
 {
     lcp_policy_list_t2_1 *pollist = NULL;
@@ -2166,6 +2471,13 @@ bool sign_lcp_policy_list_t2_1(sign_user_input user_input)
                                             user_input.pubkey_file,
                                             user_input.privkey_file);
     }
+    else if (user_input.sig_alg == TPM_ALG_LMS) {
+        pollist = policy_list2_1_lms_sign(pollist,
+                                            user_input.rev_ctr,
+                                            user_input.sig_alg,
+                                            user_input.pubkey_file,
+                                            user_input.privkey_file);
+    }
     else {
         DISPLAY("Signature algorithm not supported or not specified.\n");
         free(pollist);
@@ -2176,7 +2488,14 @@ bool sign_lcp_policy_list_t2_1(sign_user_input user_input)
         ERROR("Error: failed to sign policy list.\n");
         return false;
     }
-    result = write_tpm20_policy_list_2_1_file(user_input.list_file, pollist);
+    if (user_input.dump_sigblock) {
+        result = write_tpm20_policy_list_2_1_file(user_input.list_file,
+                                              user_input.saved_sig_file, pollist);
+    }
+    else {
+        result = write_tpm20_policy_list_2_1_file(user_input.list_file, NULL, pollist);
+    }
+    
     free(pollist);
 
     return result;

--- a/lcptools-v2/pollist2_1.h
+++ b/lcptools-v2/pollist2_1.h
@@ -70,13 +70,17 @@ lcp_policy_list_t2_1 *add_tpm20_policy_element_2_1(lcp_policy_list_t2_1
 bool verify_tpm20_pollist_2_1_sig(lcp_policy_list_t2_1 *pollist);
 bool calc_tpm20_policy_list_2_1_hash(const lcp_policy_list_t2_1 *pollist,
                                    lcp_hash_t2 *hash, uint16_t hash_alg);
-bool write_tpm20_policy_list_2_1_file(const char *file,
+bool write_tpm20_policy_list_2_1_file(const char *file, const char *signature_file,
                                     const lcp_policy_list_t2_1 *pollist);
 lcp_signature_2_1 *create_empty_ecc_signature_2_1(void);
 lcp_signature_2_1 *create_empty_rsa_signature_2_1(void);
+lcp_signature_2_1 *create_empty_lms_signature_2_1(void);
 lcp_policy_list_t2_1 *get_policy_list_2_1_data(const void *raw_data, size_t base_size,
                                              uint16_t key_signature_offset);
 bool sign_lcp_policy_list_t2_1(sign_user_input user_input);
+bool add_lcp_signature_2_1(uint16_t revocation_counter, const char *sig_file, const char *policy_list_file);
+bool add_lms_signature_and_key(const char *sig_file, const char *pubkey_file,
+                              const char *policy_list_file);
 
 #endif
 

--- a/lcptools-v2/sbios_elt.c
+++ b/lcptools-v2/sbios_elt.c
@@ -146,8 +146,9 @@ static void display(const char *prefix, const lcp_policy_element_t *elt)
 
     uint8_t *hash = (uint8_t *)get_hashes(sbios);
     for ( unsigned int i = 0; i < *get_num_hashes(sbios); i++ ) {
-        DISPLAY("%s hashes[%u]: ", prefix, i);
-        print_hex("", hash, hash_size);
+        DISPLAY("%s hashes[%u]:\n", prefix, i);
+        DISPLAY("%s", prefix);
+        print_hex("    ", hash, hash_size);
         hash += hash_size;
     }
 }

--- a/lcptools-v2/stm_elt.c
+++ b/lcptools-v2/stm_elt.c
@@ -120,8 +120,9 @@ static void display(const char *prefix, const lcp_policy_element_t *elt)
     uint8_t *hash = (uint8_t *)&stm->hashes;
     unsigned int hash_size = get_hash_size(stm->hash_alg);
     for ( unsigned int i = 0; i < stm->num_hashes; i++ ) {
-        DISPLAY("%s hashes[%u]: ", prefix, i);
-        print_hex("", hash, hash_size);
+        DISPLAY("%s hashes[%u]\n ", prefix, i);\
+        DISPLAY("%s", prefix);
+        print_hex("    ", hash, hash_size);
         hash += hash_size;
     }
 }


### PR DESCRIPTION
To use LMS:

1. Clone hash-sigs: https://github.com/cisco/hash-sigs and build the "demo" tool
2. Make sure "demo" is in your path, for example copy it to /usr/bin
3. Generate unsigned LCP list, for example like this:
    ./lcp2_mlehash --create --cmdline "logging=serial,memory,vga" --alg sha256 ../tboot/tboot.gz > tboot_hash.hash
    ./lcp2_crtpolelt --create --type mle2 --minver 0x00 --alg sha256 --ctrl 0x00 tboot_hash.hash --out tboot_mle2.elt
    ./lcp2_crtpollist --create --listver 0x300 --out tboot_lcp_list.lst tboot_mle2.elt

4. Create key pair:
    demo genkey <keyname> 20/4
5. Copy list file:
    cp tboot_lcp_list.lst lms_signed_tboot_lcp_list.lst
6. Sign:
    ./lcp2_crtpollist --verbose --sign --sigalg lms --hashalg sha256 --pub <keyname.pub> --priv <keyname.priv> --out lms_signed_tboot_lcp_list.lst

During execution new files will be created: lcp_list_digest, which contains LCP list data digest, which will be signed, and lcp_list_digest.sig which contains the signature.

The way it works is that lcp2_crtpollist will call:

demo sign <keyname> lcp_list_digest

And then read the signature that "demo" generated and build lcp_signature_2_1 structure based on that.

lcp2_crtpollist --show also works with LMS.




    

