### PR TITLE
Disable CET in the TBOOT shutdown handler

### DIFF
--- a/tboot/common/shutdown.S
+++ b/tboot/common/shutdown.S
@@ -116,8 +116,20 @@ shutdown_entry32:
  */
 ENTRY(shutdown_entry)
 	.code64
+        endbr64
 	cli
 	wbinvd
+
+        /* Disable CET*/
+        movl    $0, %eax
+        movl    $0, %edx
+        movl    $MSR_IA32_U_CET, %ecx
+        wrmsr
+
+        movl    $0, %eax
+        movl    $0, %edx
+        movl    $MSR_IA32_S_CET, %ecx
+        wrmsr
 
 	movl    $MSR_EFER,%ecx
 	rdmsr

--- a/tboot/include/msr.h
+++ b/tboot/include/msr.h
@@ -95,6 +95,10 @@ static inline void wrmsr(uint32_t msr, uint64_t newval)
 /* AMD64 MSR's */
 #define MSR_EFER        0xc0000080      /* extended features */
 
+/* CET MSRs*/
+#define MSR_IA32_U_CET  0x000006a0 /* user mode cet */
+#define MSR_IA32_S_CET  0x000006a2 /* kernel mode cet */
+
 /* EFER bits */
 #define _EFER_LME     8               /* Long mode enable */
 


### PR DESCRIPTION
During PC shutdown, the Linux Kernel works under enable Intel CET technology, which enforces indirect branch tracking (IBT) mechanism for CPU indirect jumps and calls. It prevented CPU to jump into the TBOOT shutdown handler, during PC shutdown process. In the result, Kernel threw "Missing ENDBR" bug, when CPU tried to jump to the TBOOT shutdown handler's entry.

The given bug was resolved by endbr64 instuction call at the begin of TBOOT shutdown handler and through disabling CET prior to the next CPU jump execution.

It resolves TBOOT shutdown failure bug, reported on the SLES (SUSE Linux Enterprise Server) 16.0 OS. OS power off, called by the "init 0" command, was failing, due to activated Intel Control-Flow Enforcement Technology (CET). Disabling CET has allowed to execute OS and TBOOT shutdown properly.

Closes: https://bugzilla.suse.com/show_bug.cgi?id=1247950