### PR TITLE
Secure pointer to the TBOOT Log base from unauthorized DMA access

### DIFF
--- a/include/tboot.h
+++ b/include/tboot.h
@@ -143,6 +143,7 @@ typedef struct {
 #define TBOOT_LOG_UUID   {0xc0192526, 0x6b30, 0x4db4, 0x844c, \
                              {0xa3, 0xe9, 0x53, 0xb8, 0x81, 0x74 }}
 
+extern uint32_t memlog_get_base(void);
 extern tboot_shared_t *g_tboot_shared;
 
 static inline bool tboot_in_measured_env(void)

--- a/tboot/common/memlog.c
+++ b/tboot/common/memlog.c
@@ -43,59 +43,105 @@
 
 #include <memlog.h>
 
-/* memory-based serial log (ensure in .data section so that not cleared) */
-__data tboot_log_t *g_log = NULL;
+
+/* Memory-mapped tboot log header at the fixed log region base address. */
+#define TBOOT_LOG_HDR           ((tboot_log_t *)TBOOT_SERIAL_LOG_ADDR)
+
+/* UUID for the tboot log */
+const uuid_t       tboot_log_uuid = TBOOT_LOG_UUID;
+
+/**
+ * @brief Check if the tboot log UUID is valid.
+ *
+ * @return 0 if the UUID is valid; otherwise -1.
+ */
+static int check_tboot_log_uuid(void)
+{
+    if ( tb_memcmp(&TBOOT_LOG_HDR->uuid, &tboot_log_uuid, sizeof(uuid_t)) != 0 )
+    {
+        return -1;
+    }
+    return 0;
+}
+
+/**
+ * @brief Get the base physical address of the tboot memory log region.
+ *
+ * Validates that the UUID stored in the log header matches the expected
+ * tboot log UUID. This way we can verify, if TBOOT LOG was initialized properly.
+ *
+ * @return uint32_t TBOOT_SERIAL_LOG_ADDR if the header is valid; otherwise 0.
+ */
+uint32_t memlog_get_base(void)
+{
+    if ( check_tboot_log_uuid() != 0 ) {
+        return 0;
+    }
+
+    return TBOOT_SERIAL_LOG_ADDR;
+}
 
 void memlog_init(void)
 {
-   if ( g_log == NULL ) {
-       g_log = (tboot_log_t *)TBOOT_SERIAL_LOG_ADDR;
-       uuid_t uuid = (uuid_t)TBOOT_LOG_UUID;
-       tb_memcpy((void *) &g_log->uuid, (const void *) &uuid, sizeof(uuid_t));
-       g_log->curr_pos = 0;
-       g_log->zip_count = 0;
-       for ( uint8_t i = 0; i < ZIP_COUNT_MAX; i++ ) g_log->zip_pos[i] = 0;
-       for ( uint8_t i = 0; i < ZIP_COUNT_MAX; i++ ) g_log->zip_size[i] = 0;
-       }
+    if ( check_tboot_log_uuid() != 0 )
+    {
+        uuid_t uuid = (uuid_t)TBOOT_LOG_UUID;
+        tb_memcpy((void *) &TBOOT_LOG_HDR->uuid, (const void *) &uuid, sizeof(uuid_t));
+        TBOOT_LOG_HDR->curr_pos = 0;
+        TBOOT_LOG_HDR->zip_count = 0;
+        for (uint8_t i = 0; i < ZIP_COUNT_MAX; i++)
+        {
+            TBOOT_LOG_HDR->zip_pos[i] = 0;
+            TBOOT_LOG_HDR->zip_size[i] = 0;
+        }
+    }
 
     /* initialize these post-launch as well, since bad/malicious values */
     /* could compromise environment */
-    g_log = (tboot_log_t *)TBOOT_SERIAL_LOG_ADDR;
-    g_log->max_size = TBOOT_SERIAL_LOG_SIZE - sizeof(*g_log);
+    TBOOT_LOG_HDR->max_size = TBOOT_SERIAL_LOG_SIZE - sizeof(tboot_log_t);
 
     /* if we're calling this post-launch, verify that curr_pos is valid */
-    if ( g_log->zip_pos[g_log->zip_count] > g_log->max_size && g_log != NULL ){
-        g_log->curr_pos = 0;
-        uint8_t zero = 0;
-        tb_memcpy((void *) &g_log->uuid, (const void *) &zero, sizeof(uint8_t));
-        for ( uint8_t i = 0; i < ZIP_COUNT_MAX; i++ ) g_log->zip_pos[i] = 0;
-        for ( uint8_t i = 0; i < ZIP_COUNT_MAX; i++ ) g_log->zip_size[i] = 0;
+    if ( TBOOT_LOG_HDR->zip_pos[TBOOT_LOG_HDR->zip_count] > TBOOT_LOG_HDR->max_size)
+    {
+        TBOOT_LOG_HDR->curr_pos = 0;
+
+        /* Match TBOOT LOG UUID as corrupted, when TBOOT LOG exceeds */
+        /* it's maximal size */
+        tb_memset(((void *) &TBOOT_LOG_HDR->uuid), 0, sizeof(uuid_t));
+        for ( uint8_t i = 0; i < ZIP_COUNT_MAX; i++ )
+        {
+            TBOOT_LOG_HDR->zip_pos[i] = 0;
+            TBOOT_LOG_HDR->zip_size[i] = 0;
+        }
     }
-    if ( g_log->curr_pos > g_log->max_size )
-        g_log->curr_pos = g_log->zip_pos[g_log->zip_count];
+
+    if ( TBOOT_LOG_HDR->curr_pos > TBOOT_LOG_HDR->max_size )
+    {
+        TBOOT_LOG_HDR->curr_pos = TBOOT_LOG_HDR->zip_pos[TBOOT_LOG_HDR->zip_count];
+    }
 }
 
 void memlog_write(const char *str, unsigned int count)
 {
-    if ( g_log == NULL || count > g_log->max_size ) {
+    if ( check_tboot_log_uuid() != 0 || count > TBOOT_LOG_HDR->max_size ) {
         return;
     }
 
     /* Check if there is space for the new string and a null terminator  */
-    if (g_log->curr_pos + count + 1> g_log->max_size) {
+    if (TBOOT_LOG_HDR->curr_pos + count + 1> TBOOT_LOG_HDR->max_size) {
         memlog_compress(count);
     }
 
-    tb_memcpy(&g_log->buf[g_log->curr_pos], str, count);
-    g_log->curr_pos += count; 
+    tb_memcpy(&TBOOT_LOG_HDR->buf[TBOOT_LOG_HDR->curr_pos], str, count);
+    TBOOT_LOG_HDR->curr_pos += count;
 
     /* if the string wasn't NULL-terminated, then NULL-terminate the log */
     if ( str[count-1] != '\0' )
-        g_log->buf[g_log->curr_pos] = '\0';
+        TBOOT_LOG_HDR->buf[TBOOT_LOG_HDR->curr_pos] = '\0';
     else {
         /* so that curr_pos will point to the NULL and be overwritten */
         /* on next copy */
-        g_log->curr_pos--;
+        TBOOT_LOG_HDR->curr_pos--;
     }
 }
 
@@ -108,7 +154,7 @@ void memlog_compress(uint32_t required_space)
     uint32_t zip_pos;
     bool log_reset_flag;
 
-    if (required_space == 0 && g_log->curr_pos < g_log->max_size / 2) {
+    if (required_space == 0 && TBOOT_LOG_HDR->curr_pos < TBOOT_LOG_HDR->max_size / 2) {
         /* Flush was requested, but we have over half buffer free, skip it */
         return;
     }
@@ -117,15 +163,15 @@ void memlog_compress(uint32_t required_space)
     log_reset_flag = false;
 
     /* Check if there is space to add another compressed chunk */
-    if(g_log->zip_count >= ZIP_COUNT_MAX)
+    if(TBOOT_LOG_HDR->zip_count >= ZIP_COUNT_MAX)
         log_reset_flag = true;
     else{
         /* Get the start position of the new compressed chunk */
-        zip_pos = g_log->zip_pos[g_log->zip_count];
+        zip_pos = TBOOT_LOG_HDR->zip_pos[TBOOT_LOG_HDR->zip_count];
 
         /*  Compress the last part of the log buffer that is not compressed,
             and put the compressed output in out (buf) */
-        zip_size = LZ_Compress(&g_log->buf[zip_pos], out, (g_log->curr_pos - zip_pos), sizeof(buf) );
+        zip_size = LZ_Compress(&TBOOT_LOG_HDR->buf[zip_pos], out, (TBOOT_LOG_HDR->curr_pos - zip_pos), sizeof(buf) );
 
         /* Check if buf was large enough for LZ_compress to succeed */
         if( zip_size < 0 )
@@ -133,33 +179,38 @@ void memlog_compress(uint32_t required_space)
         else{
             /*  Check if there is space to add the compressed string, the
                 new string and a null terminator to the log */
-            if( (zip_pos + zip_size + required_space + 1) > g_log->max_size )
+            if( (zip_pos + zip_size + required_space + 1) > TBOOT_LOG_HDR->max_size )
                 log_reset_flag = true;
             else{
                 /*  Add the new compressed chunk to the log buffer,
                     over-writing the last part of the log that was just
                     compressed */
-                tb_memcpy(&g_log->buf[zip_pos], out, zip_size);
-                g_log->zip_size[g_log->zip_count] = zip_size;
-                g_log->zip_count++;
-                g_log->curr_pos = zip_pos + zip_size;
+                tb_memcpy(&TBOOT_LOG_HDR->buf[zip_pos], out, zip_size);
+                TBOOT_LOG_HDR->zip_size[TBOOT_LOG_HDR->zip_count] = zip_size;
+                TBOOT_LOG_HDR->zip_count++;
+                TBOOT_LOG_HDR->curr_pos = zip_pos + zip_size;
 
                 /*  Set a NULL ending */
-                g_log->buf[g_log->curr_pos] ='\0';
+                TBOOT_LOG_HDR->buf[TBOOT_LOG_HDR->curr_pos] ='\0';
 
                 /*  Only if there is space to add another compressed chunk,
                     prepare its start position. */
-                if( g_log->zip_count < ZIP_COUNT_MAX )
-                    g_log->zip_pos[g_log->zip_count] = g_log->curr_pos;
+                if( TBOOT_LOG_HDR->zip_count < ZIP_COUNT_MAX )
+                    TBOOT_LOG_HDR->zip_pos[TBOOT_LOG_HDR->zip_count] = TBOOT_LOG_HDR->curr_pos;
             }
         }
     }
 
     /* There was some space-shortage problem. Reset the log. */
-    if ( log_reset_flag ){
-        g_log->curr_pos = 0;
-        for( uint8_t i = 0; i < ZIP_COUNT_MAX; i++ ) g_log->zip_pos[i] = 0;
-        for( uint8_t i = 0; i < ZIP_COUNT_MAX; i++ ) g_log->zip_size[i] = 0;
-        g_log->zip_count = 0;
+    if ( log_reset_flag )
+    {
+        TBOOT_LOG_HDR->curr_pos = 0;
+        for (uint8_t i = 0; i < ZIP_COUNT_MAX; i++ )
+        {
+            TBOOT_LOG_HDR->zip_pos[i]  = 0;
+            TBOOT_LOG_HDR->zip_size[i] = 0;
+        }
+
+        TBOOT_LOG_HDR->zip_count = 0;
     }
 }

--- a/tboot/common/tboot.c
+++ b/tboot/common/tboot.c
@@ -175,7 +175,6 @@ static void post_launch(void)
     tb_error_t err;
     struct tpm_if *tpm = get_tpm();
     const struct tpm_if_fp *tpm_fp = get_tpm_fp();
-    extern tboot_log_t *g_log;
     extern void shutdown_entry(void);
 
     printk(TBOOT_INFO"measured launch succeeded\n");
@@ -266,7 +265,7 @@ static void post_launch(void)
     tb_memset(&_tboot_shared, 0, PAGE_SIZE);
     _tboot_shared.uuid = (uuid_t)TBOOT_SHARED_UUID;
     _tboot_shared.version = 6;
-    _tboot_shared.log_addr = (uint32_t)g_log;
+    _tboot_shared.log_addr = memlog_get_base();
     _tboot_shared.shutdown_entry = (uint32_t)shutdown_entry;
     _tboot_shared.tboot_base = (uint32_t)&_start;
     _tboot_shared.tboot_size = (uint32_t)&_end - (uint32_t)&_start;


### PR DESCRIPTION
There exist a risk of unauthorized DMA access to the TBOOT Log base address, which could lead to information disclosure, tampering of the log data or even damaging global variables hold in the TBOOT .data section. To mitigate this risk, we can implement a secure pointer mechanism that restricts access to the TBOOT Log base address.

There were also defined 2 new functions in tboot.h from which, one of them returns the base address of the TBOOT Log and the second one validates the UUID of the TBOOT Log through these functions, ensuring that TBOOT Log was initialized properly.