### PR TITLE
Fix SGX status verification

### DIFF
--- a/tboot/include/processor.h
+++ b/tboot/include/processor.h
@@ -94,6 +94,14 @@
 #define CR4_SMXE 0x00004000/* enable SMX */
 #define CR4_PCIDE 0x00020000/* enable PCID */
 
+#define CPUID_X86_FEATURE_XMM3           (1<<0)
+#define CPUID_X86_FEATURE_VMX            (1<<5)
+#define CPUID_X86_FEATURE_SMX            (1<<6)
+#define CPUID_X86_FEATURE_SGX            (1<<18)
+
+/* Bits in EBX for CPUID leaf 7, sub-leaf 0 */
+#define CPUID_EBX_X86_SGX_SUPPORTED      (1<<2)
+
 #ifndef __ASSEMBLY__
 
 static inline void sse_enable(void)
@@ -174,9 +182,6 @@ static always_inline uint32_t cpuid_edx(unsigned int op)
 
     return regs[3];
 }
-#define CPUID_X86_FEATURE_XMM3   (1<<0)
-#define CPUID_X86_FEATURE_VMX    (1<<5)
-#define CPUID_X86_FEATURE_SMX    (1<<6)
 
 static inline unsigned long read_cr0(void)
 {

--- a/tboot/txt/acmod.c
+++ b/tboot/txt/acmod.c
@@ -1061,17 +1061,30 @@ bool verify_racm(const acm_hdr_t *acm_hdr)
 #ifndef IS_INCLUDED     /*  defined in utils/acminfo.c  */
 void verify_IA32_se_svn_status(const acm_hdr_t *acm_hdr)
 {
-    struct tpm_if *tpm = get_tpm();
+    uint32_t               ebx     = 0;
+    struct tpm_if          *tpm    = get_tpm();
     const struct tpm_if_fp *tpm_fp = get_tpm_fp();
   
     printk(TBOOT_INFO"SGX:verify_IA32_se_svn_status is called\n");
-        
-    //check if SGX is enabled by cpuid with ax=7, cx=0 
-    if ((cpuid_ebx1(7,0) & 0x00000004) == 0){
-        printk(TBOOT_ERR"SGX is not enabled, cpuid.ebx: 0x%x\n", cpuid_ebx1(7,0));
+
+    /* check if SGX is supported by cpuid with ax=7, cx=0 */
+    ebx = cpuid_ebx1(7,0);
+    if ((ebx & CPUID_EBX_X86_SGX_SUPPORTED) == 0){
+        printk(TBOOT_ERR"SGX is not supported, cpuid.ebx: 0x%x\n", ebx);
         return;
     }
-    printk(TBOOT_INFO"SGX is enabled, cpuid.ebx:0x%x\n", cpuid_ebx1(7,0));
+
+    printk(TBOOT_INFO"SGX is supported, cpuid.ebx:0x%x\n", ebx);
+
+    /* check if SGX is enabled */
+    if ((rdmsr(MSR_IA32_FEATURE_CONTROL) & CPUID_X86_FEATURE_SGX) !=
+         CPUID_X86_FEATURE_SGX){
+        printk(TBOOT_ERR"SGX is not enabled, IA32_FEATURE_CONTROL: 0x%Lx\n",
+               rdmsr(MSR_IA32_FEATURE_CONTROL));
+        return;
+    }
+
+    printk(TBOOT_INFO"SGX is enabled.\n");
     printk(TBOOT_INFO"Comparing se_svn with ACM Header se_svn\n");
     
     if (((rdmsr(MSR_IA32_SE_SVN_STATUS)>>16) & 0xff) != acm_hdr->se_svn) {


### PR DESCRIPTION
TBOOT used inproper method of the SGX status verification. It checked only if SGX is supported by checking the bit 2 of EBX returned by CPUID with leaf = 0x7 and subleaf 0. TBOOT falsely reported that SGX is enabled without MSR_IA32_FEATURE_CONTROL[bit 18] verification, which is required to enable SGX.

This patch adds the proper SGX status verification by checking both if SGX is enabled by CPUID and MSR_IA32_FEATURE_CONTROL[bit 18] set. If SGX is not enabled, it will print error message and return without doing the SVN check.